### PR TITLE
fix(template): correctly parse atom's category 

### DIFF
--- a/templates.js
+++ b/templates.js
@@ -1,6 +1,6 @@
 const rss = {
     title: 'rss/channel/title',
-    link: 'rss/channel/link|rss/channel/atom:link',
+    link: 'rss/channel/link|rss/channel/atom:link/@href',
     description: 'rss/channel/description',
     language: 'rss/channel/language',
     updated: 'rss/channel/lastBuildDate',

--- a/templates.js
+++ b/templates.js
@@ -25,7 +25,7 @@ const atom = {
         published: 'published',
         description: 'summary',
         link: 'link',
-        categories: ['category', '.']
+        categories: ['category', '@term']
     }]
 }
 

--- a/test/atom.xml
+++ b/test/atom.xml
@@ -41,5 +41,6 @@
            <p><i>[Update: The Atom draft is finished.]</i></p>
          </div>
        </content>
+       <category term="snapshot"/>
      </entry>
    </feed>

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -28,6 +28,7 @@ test('test more complicated atom feed', (t) => {
 
     t.equal(result.title, 'dive into mark', 'title should be dive into mark')
     t.equal(result.link, 'http://example.org/', 'link should be http://example.org/')
+    t.equal(result.items[0].categories[0], 'snapshot', 'category should be snapshot')
 
     t.end()
 })
@@ -38,6 +39,7 @@ test('test more complicated rss feed', (t) => {
 
     t.equal(result.title, 'Liftoff News', 'title should be Liftoff News')
     t.equal(result.link, 'http://liftoff.msfc.nasa.gov/', 'link should be http://liftoff.msfc.nasa.gov/')
+    t.equal(result.items[0].categories[0], 'star', 'category of first post should be star')
 
     t.end()
 })

--- a/test/rss.xml
+++ b/test/rss.xml
@@ -17,11 +17,13 @@
          <description>How do Americans get ready to work with Russians aboard the International Space Station? They take a crash course in culture, language and protocol at Russia's &lt;a href="http://howe.iki.rssi.ru/GCTC/gctc_e.htm"&gt;Star City&lt;/a&gt;.</description>
          <pubDate>Tue, 03 Jun 2003 09:39:21 GMT</pubDate>
          <guid>http://liftoff.msfc.nasa.gov/2003/06/03.html#item573</guid>
+         <category>star</category>
       </item>
       <item>
          <description>Sky watchers in Europe, Asia, and parts of Alaska and Canada will experience a &lt;a href="http://science.nasa.gov/headlines/y2003/30may_solareclipse.htm"&gt;partial eclipse of the Sun&lt;/a&gt; on Saturday, May 31st.</description>
          <pubDate>Fri, 30 May 2003 11:06:42 GMT</pubDate>
          <guid>http://liftoff.msfc.nasa.gov/2003/05/30.html#item572</guid>
+         <category>sky</category>
       </item>
       <item>
          <title>The Engine That Does More</title>
@@ -29,6 +31,7 @@
          <description>Before man travels to Mars, NASA hopes to design new engines that will let us fly through the Solar System more quickly.  The proposed VASIMR engine would do that.</description>
          <pubDate>Tue, 27 May 2003 08:37:32 GMT</pubDate>
          <guid>http://liftoff.msfc.nasa.gov/2003/05/27.html#item571</guid>
+         <category>engine</category>
       </item>
       <item>
          <title>Astronauts' Dirty Laundry</title>
@@ -36,6 +39,7 @@
          <description>Compared to earlier spacecraft, the International Space Station has many luxuries, but laundry facilities are not one of them.  Instead, astronauts have other options.</description>
          <pubDate>Tue, 20 May 2003 08:56:02 GMT</pubDate>
          <guid>http://liftoff.msfc.nasa.gov/2003/05/20.html#item570</guid>
+         <category>laundry</category>
       </item>
    </channel>
 </rss>


### PR DESCRIPTION
https://validator.w3.org/feed/docs/atom.html#category

``` xml
<category term="foo" scheme="https://example.com/tags/foo/"/>
<category term="bar" scheme="https://example.com/tags/bar/"/>
```

https://validator.w3.org/feed/docs/atom.html#recommendedFeedElements

``` xml
<atom:link href="https://example.com/foo.xml"/>
```