### PR TITLE
fix: update camaro from v1 to v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,5 @@ node_js:
   - "6"
   - "7"
   - "8"
-env:
-  - CXX=g++-5
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-5
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 node_js:
-  - "6"
-  - "7"
-  - "8"
+  - '8'
+  - '9'
+  - '10'
+  - '11'
+  - '12'
+  - '13'
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ node_js:
   - '11'
   - '12'
   - '13'
+
+cache:
+  npm: true
 script:
   - npm test

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ npm install feed-furious
 ## Usage
 
 ```js
+const { parse } = require('feed-furious')
+
 const xml = '<feed><title><![CDATA[Hello]]> <![CDATA[World]]></title><entry>' +
     '<link>http://example.com/1</link>' +
     '<content><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc varius mattis convallis. ' +
@@ -27,7 +29,12 @@ const xml = '<feed><title><![CDATA[Hello]]> <![CDATA[World]]></title><entry>' +
     'Donec eget placerat lacus.]]></content>' +
     '</entry></feed>'
 
-const result = parse(xml)
+const parseFeed = async () => {
+    const result = await parse(xml)
+    console.log(result)
+}
+
+parseFeed()
 ```
 
 ## Licence

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const transform = require('camaro')
+const { transform } = require('camaro')
 const templates = require('./templates')
 
-function detectFeedType(xml) {
-    const sample = transform(xml, {
+async function detectFeedType(xml) {
+    const sample = await transform(xml, {
         rss: 'rss/channel/title',
         atom: 'feed/title'
     })
@@ -12,9 +12,10 @@ function detectFeedType(xml) {
     throw new Error('unknown feed type')
 }
 
-function parse(xml) {
-    const type = detectFeedType(xml)
-    return transform(xml, templates[type])
+async function parse(xml) {
+    const type = await detectFeedType(xml)
+    const result = await transform(xml, templates[type])
+    return result
 }
 
 module.exports = { parse }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "tape test/*.test.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git@github.com:tuananh/feed-furious.git"
-  },
+  "repository": "github:tuananh/feed-furious",
   "keywords": [
     "feed",
     "parser"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Tuan Anh Tran <me@tuananh.org> (https://tuananh.org)",
   "license": "MIT",
   "dependencies": {
-    "camaro": "^1.0.4"
+    "camaro": "^4.1.2"
   },
   "devDependencies": {
     "tape": "^4.6.3"

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,8 +1,8 @@
 const { parse } = require('../')
-const fs = require('fs')
+const { readFile } = require('fs').promises
 const test = require('tape')
 
-test('test simple atom feed', (t) => {
+test('test simple atom feed', async (t) => {
     const xml = '<feed><title><![CDATA[Hello]]> <![CDATA[World]]></title><entry>' +
     '<link>http://example.com/1</link>' +
     '<content><![CDATA[Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc varius mattis convallis. ' +
@@ -15,16 +15,16 @@ test('test simple atom feed', (t) => {
     'Donec eget placerat lacus.]]></content>' +
     '</entry></feed>'
 
-    const result = parse(xml)
+    const result = await parse(xml)
     t.equal(result.title, 'HelloWorld', 'title should be HelloWorld')
     t.equal(result.items[0].link, 'http://example.com/1', 'link should be http://example.com/1')
 
     t.end()
 })
 
-test('test more complicated atom feed', (t) => {
-    const xml = fs.readFileSync(__dirname + '/atom.xml', 'utf-8')
-    const result = parse(xml)
+test('test more complicated atom feed', async (t) => {
+    const xml = await readFile(__dirname + '/atom.xml', 'utf-8')
+    const result = await parse(xml)
 
     t.equal(result.title, 'dive into mark', 'title should be dive into mark')
     t.equal(result.link, 'http://example.org/', 'link should be http://example.org/')
@@ -33,9 +33,9 @@ test('test more complicated atom feed', (t) => {
     t.end()
 })
 
-test('test more complicated rss feed', (t) => {
-    const xml = fs.readFileSync(__dirname + '/rss.xml', 'utf-8')
-    const result = parse(xml)
+test('test more complicated rss feed', async (t) => {
+    const xml = await readFile(__dirname + '/rss.xml', 'utf-8')
+    const result = await parse(xml)
 
     t.equal(result.title, 'Liftoff News', 'title should be Liftoff News')
     t.equal(result.link, 'http://liftoff.msfc.nasa.gov/', 'link should be http://liftoff.msfc.nasa.gov/')

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,5 +1,6 @@
 const { parse } = require('../')
-const { readFile } = require('fs').promises
+const { promisify } = require('util')
+const readFile = promisify(require('fs').readFile)
 const test = require('tape')
 
 test('test simple atom feed', async (t) => {


### PR DESCRIPTION
- utilize async-ed camaro v4
- utilize promisified fs.readFile
- directly execute `npm test` in CI
- drop Node 6 in CI
- add Node 9-13 to CI (as used in [camaro](https://github.com/tuananh/camaro/blob/a32866234155ac989749043a91edee92b2b6355a/.travis.yml#L9-L14))